### PR TITLE
Fixed os version for some cases

### DIFF
--- a/percy/metadata/metadata.js
+++ b/percy/metadata/metadata.js
@@ -27,7 +27,8 @@ class Metadata {
   }
 
   async osVersion() {
-    return (await this.caps()).osVersion?.split('.')[0];
+    const caps = await this.caps();
+    return (caps.osVersion || caps.platformVersion)?.split('.')[0];
   }
 
   async orientation() {

--- a/test/percy/metadata/metadata.test.mjs
+++ b/test/percy/metadata/metadata.test.mjs
@@ -38,6 +38,16 @@ describe('Metadata', () => {
       mockCaps({ osVersion: '12.5' });
       expect(await metadata.osVersion()).toEqual('12');
     });
+
+    it('returns major os version from platform caps', async () => {
+      mockCaps({ platformVersion: '12.5' });
+      expect(await metadata.osVersion()).toEqual('12');
+    });
+
+    it('returns major os version if both osVersion and platformVersion are present', async () => {
+      mockCaps({ osVersion: '12.5', platformVersion: '13.7' }); // keeping different for test
+      expect(await metadata.osVersion()).toEqual('12');
+    });
   });
 
   describe('orientation', () => {


### PR DESCRIPTION
- Fixed cases where `osVersion` key was missing, falling back on `platformVersion` instead