### PR TITLE
[Fix] External debug url not passed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@percy/appium-app",
   "description": "Appium client library for visual testing with Percy",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "license": "MIT",
   "author": "Perceptual Inc.",
   "repository": {

--- a/percy/providers/genericProvider.js
+++ b/percy/providers/genericProvider.js
@@ -58,7 +58,7 @@ class GenericProvider {
       name,
       tag,
       tiles,
-      externalDebugUrl: this.getDebugUrl(),
+      externalDebugUrl: await this.getDebugUrl(),
       environmentInfo: ENV_INFO,
       clientInfo: CLIENT_INFO
     });


### PR DESCRIPTION
- Fixed missing `await` on external debug url [ test pending as jasmine unable to mock it ]
- Bumped version to 0.0.4 