### PR TITLE
fix: dependency version for percy/cli

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,6 +92,8 @@ module.exports = async function percyScreenshot(driver, name, options = {}) {
   });
 };
 
+// jasmine cannot mock individual functions, hence adding isPercyEnabled to the exports object
+// also need to define this at the end of the file or else default exports will over-ride this
 module.exports.isPercyEnabled = async function isPercyEnabled(driver) {
   if (!(await utils.isPercyEnabled())) return false;
 

--- a/index.js
+++ b/index.js
@@ -6,12 +6,6 @@ const percyOnAutomate = require('./percy/percyOnAutomate');
 const log = require('./percy/util/log');
 const utils = require('@percy/sdk-utils');
 
-async function isPercyEnabled(driver) {
-  if (!(await utils.isPercyEnabled())) return false;
-
-  return (await driver.getPercyOptions()).enabled;
-}
-
 module.exports = async function percyScreenshot(driver, name, options = {}) {
   let {
     fullscreen,
@@ -63,14 +57,14 @@ module.exports = async function percyScreenshot(driver, name, options = {}) {
   log.debug(`[${name}] -> begin`);
   driver = new AppiumDriver(driver);
 
-  if (!await isPercyEnabled(driver)) {
+  if (!await module.exports.isPercyEnabled(driver)) {
     log.info(`[${name}] percy is disabled for session ${driver.sessionId} -> end`);
     return;
   };
   return TimeIt.run('percyScreenshot', async () => {
     try {
       if (utils.percy?.type === 'automate') {
-        return percyOnAutomate(driver, name, options);
+        return await percyOnAutomate(driver, name, options);
       }
       const provider = ProviderResolver.resolve(driver);
       const response = await provider.screenshot(name, {
@@ -97,3 +91,9 @@ module.exports = async function percyScreenshot(driver, name, options = {}) {
     }
   });
 };
+
+module.exports.isPercyEnabled = async function isPercyEnabled(driver) {
+  if (!(await utils.isPercyEnabled())) return false;
+
+  return (await driver.getPercyOptions()).enabled;
+}

--- a/index.js
+++ b/index.js
@@ -98,4 +98,4 @@ module.exports.isPercyEnabled = async function isPercyEnabled(driver) {
   if (!(await utils.isPercyEnabled())) return false;
 
   return (await driver.getPercyOptions()).enabled;
-}
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@percy/appium-app",
   "description": "Appium client library for visual testing with Percy",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "license": "MIT",
   "author": "Perceptual Inc.",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test:types": "tsd"
   },
   "dependencies": {
-    "@percy/sdk-utils": "^1.25.0",
+    "@percy/sdk-utils": "^1.27.0-beta.0",
     "tmp": "^0.2.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "tmp": "^0.2.1"
   },
   "devDependencies": {
-    "@percy/cli": "^1.25.0",
+    "@percy/cli": "^1.27.0-beta.0",
     "cross-env": "^7.0.2",
     "eslint": "^8.27.0",
     "eslint-plugin-n": "^15.5.1",

--- a/test/index.test.mjs
+++ b/test/index.test.mjs
@@ -221,6 +221,7 @@ describe('percyScreenshot', () => {
 
       it('should call POA percyScreenshot', async () => {
         const driver = driverFunc({ enabled: true });
+        spyOn(percyScreenshot, 'isPercyEnabled').and.returnValue(Promise.resolve(true))
         utils.percy.type = 'automate';
         spyOn(percyOnAutomate, 'request').and.callFake(() => {});
 
@@ -233,6 +234,7 @@ describe('percyScreenshot', () => {
       it('should call POA percyScreenshot with ignoreRegion', async () => {
         const element = { value: '123', elementId: '123' };
         const driver = driverFunc({ enabled: true });
+        spyOn(percyScreenshot, 'isPercyEnabled').and.returnValue(Promise.resolve(true))
         utils.percy.type = 'automate';
         spyOn(percyOnAutomate, 'request').and.callFake(() => {});
 
@@ -247,8 +249,9 @@ describe('percyScreenshot', () => {
 
       it('should handle error POA', async () => {
         const driver = driverFunc({ enabled: true, ignoreErrors: false });
+        spyOn(percyScreenshot, 'isPercyEnabled').and.returnValue(Promise.resolve(true))
         utils.percy.type = 'automate';
-        spyOn(percyOnAutomate, 'request').and.callFake(() => { throw Error('Not found 404'); });
+        spyOn(percyOnAutomate, 'request').and.returnValue(Promise.reject(new Error('Not found 404')));
         let error = null;
         try {
           await percyScreenshot(driver, 'Screenshot 2');
@@ -260,7 +263,9 @@ describe('percyScreenshot', () => {
 
       it('should handle error POA ignoreError false', async () => {
         const driver = driverFunc({ enabled: true, ignoreErrors: true });
-        driver.sessionId = '1234';
+        spyOn(percyScreenshot, 'isPercyEnabled').and.returnValue(Promise.resolve(true))
+        utils.percy.type = 'automate';
+        spyOn(percyOnAutomate, 'request').and.returnValue(Promise.reject(new Error('Not found 404')));
         let error = null;
         try {
           await percyScreenshot(driver, 'Screenshot 3');

--- a/yarn.lock
+++ b/yarn.lock
@@ -300,105 +300,106 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@percy/cli-app@1.25.0":
-  version "1.25.0"
-  resolved "https://registry.yarnpkg.com/@percy/cli-app/-/cli-app-1.25.0.tgz#ac4a6c671a7d65279b881a2fd659acd9fc8b7222"
-  integrity sha512-49fRI8Vmf6OhHxwxrbTznsmJv6WY481tedILJIpb1zJSaVtNA7JHCreqdRlBzG7UusTD2iNJZ1t99F1yxx5x+Q==
+"@percy/cli-app@1.27.0-beta.0":
+  version "1.27.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@percy/cli-app/-/cli-app-1.27.0-beta.0.tgz#83080d7d011ae10d204e2f0bcc53fb560f959c3d"
+  integrity sha512-i80q+Yu+h8vUwbAELzGferrG9mDZJdAG0YHI3lL8zpK7sTOI6lFlbMMeBIDnHio3xy3r6xAyTuXUt2kFgXwTEA==
   dependencies:
-    "@percy/cli-command" "1.25.0"
-    "@percy/cli-exec" "1.25.0"
+    "@percy/cli-command" "1.27.0-beta.0"
+    "@percy/cli-exec" "1.27.0-beta.0"
 
-"@percy/cli-build@1.25.0":
-  version "1.25.0"
-  resolved "https://registry.yarnpkg.com/@percy/cli-build/-/cli-build-1.25.0.tgz#a67a2e734dd8df39917e2f40a976994a0f0aae87"
-  integrity sha512-6ewm7AxcH4Kvcb8k8wD5BHNJE//Rx0MupOZUFo7AtebIyWtEeZB7aGWEyIzcLcHsuRad5LtQBHI/ZeZyAOsnew==
+"@percy/cli-build@1.27.0-beta.0":
+  version "1.27.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@percy/cli-build/-/cli-build-1.27.0-beta.0.tgz#4a511d22f676f1ec238f3af712d5ac22c0d3bf9f"
+  integrity sha512-GuwoP492tP8X85cXu530dDitQnry/F48bWLhSWTtxR4rO6xXcc3RC41Ppoz5kzy/IMqHHA/l1GhTpluhbA18NQ==
   dependencies:
-    "@percy/cli-command" "1.25.0"
+    "@percy/cli-command" "1.27.0-beta.0"
 
-"@percy/cli-command@1.25.0":
-  version "1.25.0"
-  resolved "https://registry.yarnpkg.com/@percy/cli-command/-/cli-command-1.25.0.tgz#afc5ff5936ce81964d65f21d9f00d69a07af4fe7"
-  integrity sha512-EKkQ3uzrTnq/kRBB1/K+Nvd+JXoAH3WXXQLKMFamfUOkeuT43srXlufXMKQw/+rOpO+QJnQOAfn1yj/4HFOBAA==
+"@percy/cli-command@1.27.0-beta.0":
+  version "1.27.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@percy/cli-command/-/cli-command-1.27.0-beta.0.tgz#7293f59f0d99740cd0ec0e3e6a0df067dae87d02"
+  integrity sha512-p6vbRFnjvgJcsC/mgoPYRWrMH9BjZbRQVHb49R+dwUSdVPfM4xBpM0Q5Qjzst85rd0k08nsfDDCetRLAoNDcIg==
   dependencies:
-    "@percy/config" "1.25.0"
-    "@percy/core" "1.25.0"
-    "@percy/logger" "1.25.0"
+    "@percy/config" "1.27.0-beta.0"
+    "@percy/core" "1.27.0-beta.0"
+    "@percy/logger" "1.27.0-beta.0"
 
-"@percy/cli-config@1.25.0":
-  version "1.25.0"
-  resolved "https://registry.yarnpkg.com/@percy/cli-config/-/cli-config-1.25.0.tgz#678ffcdcc59ee92d2fccadae991743e947a9e059"
-  integrity sha512-sXGliQdeKgPQL++zusfe6mobmLT69cVLccLfqD5VUHC4HqaaEXdiCJIzzKnxHBLaZFk5JRd4++CU+Vy9ACtRSw==
+"@percy/cli-config@1.27.0-beta.0":
+  version "1.27.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@percy/cli-config/-/cli-config-1.27.0-beta.0.tgz#bad6fc692d0863fac34ae637d2fd34ab57faff2f"
+  integrity sha512-yVpSxCusOxOwduHppXal5xGj2Hd22Jc2798QNu4zUuTsZx1zhCVKaqa3wJxgBHhyaX+yECwENxywiDziMWlyWw==
   dependencies:
-    "@percy/cli-command" "1.25.0"
+    "@percy/cli-command" "1.27.0-beta.0"
 
-"@percy/cli-exec@1.25.0":
-  version "1.25.0"
-  resolved "https://registry.yarnpkg.com/@percy/cli-exec/-/cli-exec-1.25.0.tgz#46872e8de422b4415b420d76ab77ff9376bd3411"
-  integrity sha512-httlYtYJ3bD+9VihEZL8CQzJ9ykR1THPfN9Ww6WGqBG2IGCe8Ln/6hZ/ivSK7IgW8OoRb6V/3qApGYpVD8dS8Q==
+"@percy/cli-exec@1.27.0-beta.0":
+  version "1.27.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@percy/cli-exec/-/cli-exec-1.27.0-beta.0.tgz#ddf71937964c71393bb19b05d5684a82bde66baf"
+  integrity sha512-gFd0lk752fni+/RWcK7T+FkDymlNUKSn+z+/HpastIC/XSHjtsswuwODuHA1D3T/TpUZVUIVP8A2zJZE/sb+bg==
   dependencies:
-    "@percy/cli-command" "1.25.0"
+    "@percy/cli-command" "1.27.0-beta.0"
     cross-spawn "^7.0.3"
     which "^2.0.2"
 
-"@percy/cli-snapshot@1.25.0":
-  version "1.25.0"
-  resolved "https://registry.yarnpkg.com/@percy/cli-snapshot/-/cli-snapshot-1.25.0.tgz#cd6c6965cd1286c3c46716b4eac078eeb56d9e4e"
-  integrity sha512-JtaW7SVWOr13iuE9E5ZsTAmXDC0oSYV75EvhF3zh8sXUa2Q/bjbhLI52kewThmkqOETREWrKc2uVkYEqWSQYXA==
+"@percy/cli-snapshot@1.27.0-beta.0":
+  version "1.27.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@percy/cli-snapshot/-/cli-snapshot-1.27.0-beta.0.tgz#09638f42341daade5bf9e01a867b0aff49b885d1"
+  integrity sha512-oXBrYH7uM19B5BC3f8zkwWDOMvoZwJHapdwIzOTEiB1pXI1oM6d9vg1ieO8l3DZvw3jyAsi5dmmU4zcAVzrUYQ==
   dependencies:
-    "@percy/cli-command" "1.25.0"
+    "@percy/cli-command" "1.27.0-beta.0"
     yaml "^2.0.0"
 
-"@percy/cli-upload@1.25.0":
-  version "1.25.0"
-  resolved "https://registry.yarnpkg.com/@percy/cli-upload/-/cli-upload-1.25.0.tgz#1c9a4c634401c558a7eee2c611a9fdf75b87fc6d"
-  integrity sha512-ZhSHkCKWvUMqkWIIL2WedVbkTs17alYlGnt2QPHHDbxdqcV4dAgv/O08JVHmI2pf5fTCGe8hD2XHT508R4novg==
+"@percy/cli-upload@1.27.0-beta.0":
+  version "1.27.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@percy/cli-upload/-/cli-upload-1.27.0-beta.0.tgz#6e0f8b3cd292ca4cb0673f85721d0762b372dba2"
+  integrity sha512-nxdwQ8+UB3xXRz0YBruI57hWkMSvkzR5DyKQ/jmLVj+3CcUMh0lFN/Oj6mIJjrkr9+B8cWZjWl6AYKH5C+XbNA==
   dependencies:
-    "@percy/cli-command" "1.25.0"
+    "@percy/cli-command" "1.27.0-beta.0"
     fast-glob "^3.2.11"
     image-size "^1.0.0"
 
-"@percy/cli@^1.25.0":
-  version "1.25.0"
-  resolved "https://registry.yarnpkg.com/@percy/cli/-/cli-1.25.0.tgz#c665d312e025916a7c67b445fe0ca85b6d5f7930"
-  integrity sha512-j8+NgscX4723zJupPLkKcFu36srdv10xPrqYxU2W2IbaAKhTLUO9o4vMVr+4Z0bfjzYKnZuH4H+36xV+bdoSCA==
+"@percy/cli@^1.27.0-beta.0":
+  version "1.27.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@percy/cli/-/cli-1.27.0-beta.0.tgz#775f2510f505dd66f45bc0727d5b7e030fa293b7"
+  integrity sha512-X5mGNXCOPMnbhaVDOqtd33xK6BkQUgzMS0hwcMH8xwQgd248emsODqHIkhWgBodt+ERJt0hnf4rgkidndMWQvQ==
   dependencies:
-    "@percy/cli-app" "1.25.0"
-    "@percy/cli-build" "1.25.0"
-    "@percy/cli-command" "1.25.0"
-    "@percy/cli-config" "1.25.0"
-    "@percy/cli-exec" "1.25.0"
-    "@percy/cli-snapshot" "1.25.0"
-    "@percy/cli-upload" "1.25.0"
-    "@percy/client" "1.25.0"
-    "@percy/logger" "1.25.0"
+    "@percy/cli-app" "1.27.0-beta.0"
+    "@percy/cli-build" "1.27.0-beta.0"
+    "@percy/cli-command" "1.27.0-beta.0"
+    "@percy/cli-config" "1.27.0-beta.0"
+    "@percy/cli-exec" "1.27.0-beta.0"
+    "@percy/cli-snapshot" "1.27.0-beta.0"
+    "@percy/cli-upload" "1.27.0-beta.0"
+    "@percy/client" "1.27.0-beta.0"
+    "@percy/logger" "1.27.0-beta.0"
 
-"@percy/client@1.25.0":
-  version "1.25.0"
-  resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.25.0.tgz#5c50bfdb8086e7d42a06359854b484a10ed257eb"
-  integrity sha512-5xWnUkUyosaNhZnpatYidzbugsCY3V9RK8o+ISw5+LZ71Tl9bS/YtbUmwqR2n03dTJmvuDOxtcDbrFubW+mqfQ==
+"@percy/client@1.27.0-beta.0":
+  version "1.27.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.27.0-beta.0.tgz#c41953b5641975297cf15332f6a3cdde80c9cd51"
+  integrity sha512-yH+FoCEkpSx0MO5cqL489q9HIQcWCj4ZCPhY1cBh5J7MJuwDv0jRc7HB5xlqVUSj17l7Wqn6bT/ieLrY/dv0MA==
   dependencies:
-    "@percy/env" "1.25.0"
-    "@percy/logger" "1.25.0"
+    "@percy/env" "1.27.0-beta.0"
+    "@percy/logger" "1.27.0-beta.0"
 
-"@percy/config@1.25.0":
-  version "1.25.0"
-  resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.25.0.tgz#bfaf968a342f906e6e4db794f98a16c612cd9107"
-  integrity sha512-Ryfz29Q5j3QlibxlTXOfJPmykk5Fli7fIle09GeM57cWu03Q8IjMCXi2fP5++8XCBZoKXh/cHNKMK8B7AyD/Hw==
+"@percy/config@1.27.0-beta.0":
+  version "1.27.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.27.0-beta.0.tgz#a3ff367acf1001ba31792f65ae9700c2c6ede6c6"
+  integrity sha512-AvR5mnhm5lUVw3fOhFeVDshz53Vlgl8UzSb+cgRguRow72PSibgKUoS9b0JA1n3b7CSeaoWGycGOQ4jUOsFl+A==
   dependencies:
-    "@percy/logger" "1.25.0"
+    "@percy/logger" "1.27.0-beta.0"
     ajv "^8.6.2"
     cosmiconfig "^8.0.0"
     yaml "^2.0.0"
 
-"@percy/core@1.25.0":
-  version "1.25.0"
-  resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.25.0.tgz#bf01129d3c461f7d6f705aa5e4b6de5cf6d5e4c9"
-  integrity sha512-FxM44alygp19wI7/Fby2Eo4LN0BiZz6CXPPyrPfAxPZnScGBLfJm6fU7pQ4gps79/klXLaaDSuLs4MhRk4n9ng==
+"@percy/core@1.27.0-beta.0":
+  version "1.27.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.27.0-beta.0.tgz#3d1b6100ad78d9ce583ef7c0425df2d84ca921b3"
+  integrity sha512-U0x3VHbxfo8Ho9j/JlHYstV/MUsTB9uAQYMgsI0WAnq67TbyGY6u/g8mqi9DeXnafk3YOM2YQ7RaLaUo8/re0Q==
   dependencies:
-    "@percy/client" "1.25.0"
-    "@percy/config" "1.25.0"
-    "@percy/dom" "1.25.0"
-    "@percy/logger" "1.25.0"
+    "@percy/client" "1.27.0-beta.0"
+    "@percy/config" "1.27.0-beta.0"
+    "@percy/dom" "1.27.0-beta.0"
+    "@percy/logger" "1.27.0-beta.0"
+    "@percy/webdriver-utils" "1.27.0-beta.0"
     content-disposition "^0.5.4"
     cross-spawn "^7.0.3"
     extract-zip "^2.0.1"
@@ -409,27 +410,35 @@
     rimraf "^3.0.2"
     ws "^8.0.0"
 
-"@percy/dom@1.25.0":
-  version "1.25.0"
-  resolved "https://registry.yarnpkg.com/@percy/dom/-/dom-1.25.0.tgz#cbc9730a034acb0939eae6500b3b38e00ddcbcfb"
-  integrity sha512-zBTFC75SM5LfRKZ9n0izvzcfTszCPwKRlulOEu4HQDATpzZuIIwyfM+5EuHthbt+E2PDkgiycbji4T66HnoRGA==
+"@percy/dom@1.27.0-beta.0":
+  version "1.27.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@percy/dom/-/dom-1.27.0-beta.0.tgz#db768db620da48dd667ac0e8d927948bef3f1042"
+  integrity sha512-qmZfuAoVstQ8pXvdbS86uaK9NKbtnOYv5xOyvSMgT3kdoSrvdbtqK9FtmTh3g6kUDD7XrQAYdiuyTr7veu/7rQ==
 
-"@percy/env@1.25.0":
-  version "1.25.0"
-  resolved "https://registry.yarnpkg.com/@percy/env/-/env-1.25.0.tgz#679babbe32f1aaff913fa0aaed2650b27996e0c8"
-  integrity sha512-Ds08lRk/TfrpTyIExLkzBI9PmIxVb2mm+UcAN/te7nhWcYB33rw3mO+U4+4WxhMQOh5QTLweaZEwEFx8uTx11A==
+"@percy/env@1.27.0-beta.0":
+  version "1.27.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@percy/env/-/env-1.27.0-beta.0.tgz#89307084f525c21d9451f8b73082060b8d549f35"
+  integrity sha512-aB4sJKNmEf6/JClW206kTzSKUzkibq026CXGBtll8UH9TyxhNuX1La4img9kndaILnUKylFG9fb3JIl4jby8ng==
   dependencies:
-    "@percy/logger" "1.25.0"
+    "@percy/logger" "1.27.0-beta.0"
 
-"@percy/logger@1.25.0":
-  version "1.25.0"
-  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.25.0.tgz#e6838d3b5ba65431e8f14b831345c1fbb96a600f"
-  integrity sha512-S5xaDIG16vUChKdHSeOjmAsLpIZ+JzzAdTdmXLy+MDcqU//iZcaY5aOH7h2zR7U/h4WUGe71YDWx2C5dOskMhQ==
+"@percy/logger@1.27.0-beta.0":
+  version "1.27.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.27.0-beta.0.tgz#03ab52c8199071d677ed855596738048b686ae39"
+  integrity sha512-aVlXQ1agKiR0NJipEMz27JXWrtxEuT+QwtoWVFxz1SHLxOxNWlWXL9whOuj8X6jIDKFR9vZ2PttQrhyWKZFw5g==
 
-"@percy/sdk-utils@^1.25.0":
-  version "1.25.0"
-  resolved "https://registry.yarnpkg.com/@percy/sdk-utils/-/sdk-utils-1.25.0.tgz#25be9e8d5a2d702969aaff26dc1bec1186b692dd"
-  integrity sha512-jv4/jb3Neh4IgHUOuuB11XbC0Ho7dLH9plRM1JcBwxaoaTeGL9Ftau3OC126320K37yRTO4KZ+sW3jxQk/Ghsw==
+"@percy/sdk-utils@1.27.0-beta.0", "@percy/sdk-utils@^1.27.0-beta.0":
+  version "1.27.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@percy/sdk-utils/-/sdk-utils-1.27.0-beta.0.tgz#b6be92d6aeaf4876a042fd9833742d229573ea95"
+  integrity sha512-WsKtSNkSSbqjj+9KZ+7dG7RFApS7VkdgQxYeyTN/DwwqI627JgZZk7OKnJ99OHpL90gj33KJc01Uhft73HtMYA==
+
+"@percy/webdriver-utils@1.27.0-beta.0":
+  version "1.27.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@percy/webdriver-utils/-/webdriver-utils-1.27.0-beta.0.tgz#0943deb560786be34e5f333d9949b4677548e600"
+  integrity sha512-Ij5vuTm7PH8YSE+h+Sw7dqZ0lQsc5mEqnQ7bjLntLtdH1wcQOSUlF2w9aL+ZgCo/Jrsl+QI+sTfU0K8HAdbeug==
+  dependencies:
+    "@percy/config" "1.27.0-beta.0"
+    "@percy/sdk-utils" "1.27.0-beta.0"
 
 "@sindresorhus/is@^4.0.0":
   version "4.6.0"


### PR DESCRIPTION
**Context-**
- Updated `@percy/cli` package to `1.27.0-beta.0`
- This broke tests as we will call the newer `sdkUtils.isPercyEnabled()` function now, which will update the `utils.type` which we explicitly set to navigate to `POA` workflow.
- Hence needed to move `isPercyEnabled()` function to `module.exports.isPercyEnabled` so that jasmine could mock it effectively.
- Also a minor fix when returning from `POA` main call.