### PR TITLE
making singlepage call to remote by default

### DIFF
--- a/percy/providers/appAutomateProvider.js
+++ b/percy/providers/appAutomateProvider.js
@@ -96,7 +96,8 @@ class AppAutomateProvider extends GenericProvider {
   // Override this for AA specific optimizations
   async getTiles(fullscreen, fullPage, screenLengths, scrollableXpath, scrollableId) {
     // Temporarily restrict AA optimizations only for full page
-    if (process.env.PERCY_DISABLE_REMOTE_UPLOADS === 'true') {
+    console.log(`env:- ${process.env.PERCY_DISABLE_REMOTE_UPLOADS}`);
+    if (this.isDisableRemoteUpload()) {
       return await super.getTiles(fullscreen, fullPage, screenLengths);
     }
 
@@ -105,7 +106,7 @@ class AppAutomateProvider extends GenericProvider {
     if (fullPage !== true) {
       screenshotType = 'singlepage';
     }
-    if (process.env.PERCY_ENABLE_DEV === 'true') {
+    if (this.isPercyDev()) {
       projectId = 'percy-dev';
     }
     // Take screenshots via browserstack executor
@@ -160,6 +161,14 @@ class AppAutomateProvider extends GenericProvider {
     const buildHash = result.buildHash;
     const sessionHash = result.sessionHash;
     this.debugUrl = `https://app-automate.browserstack.com/dashboard/v2/builds/${buildHash}/sessions/${sessionHash}`;
+  }
+
+  isDisableRemoteUpload() {
+    return process.env.PERCY_DISABLE_REMOTE_UPLOADS === 'true';
+  }
+
+  isPercyDev() {
+    return process.env.PERCY_ENABLE_DEV === 'true';
   }
 }
 

--- a/percy/providers/appAutomateProvider.js
+++ b/percy/providers/appAutomateProvider.js
@@ -97,6 +97,9 @@ class AppAutomateProvider extends GenericProvider {
   async getTiles(fullscreen, fullPage, screenLengths, scrollableXpath, scrollableId) {
     // Override AA optimizations
     if (this.isDisableRemoteUpload()) {
+      if (fullPage === true) {
+        log.warn('Full page screenshots are only supported when "PERCY_DISABLE_REMOTE_UPLOADS" is not set');
+      }
       return await super.getTiles(fullscreen, fullPage, screenLengths);
     }
 

--- a/percy/providers/appAutomateProvider.js
+++ b/percy/providers/appAutomateProvider.js
@@ -95,8 +95,7 @@ class AppAutomateProvider extends GenericProvider {
 
   // Override this for AA specific optimizations
   async getTiles(fullscreen, fullPage, screenLengths, scrollableXpath, scrollableId) {
-    // Temporarily restrict AA optimizations only for full page
-    console.log(`env:- ${process.env.PERCY_DISABLE_REMOTE_UPLOADS}`);
+    // Override AA optimizations
     if (this.isDisableRemoteUpload()) {
       return await super.getTiles(fullscreen, fullPage, screenLengths);
     }

--- a/percy/providers/appAutomateProvider.js
+++ b/percy/providers/appAutomateProvider.js
@@ -96,16 +96,25 @@ class AppAutomateProvider extends GenericProvider {
   // Override this for AA specific optimizations
   async getTiles(fullscreen, fullPage, screenLengths, scrollableXpath, scrollableId) {
     // Temporarily restrict AA optimizations only for full page
-    if (fullPage !== true) {
+    if (process.env.PERCY_DISABLE_REMOTE_UPLOADS === 'true') {
       return await super.getTiles(fullscreen, fullPage, screenLengths);
     }
 
+    let screenshotType = 'fullpage';
+    let projectId = 'percy-prod';
+    if (fullPage !== true) {
+      screenshotType = 'singlepage';
+    }
+    if (process.env.PERCY_ENABLE_DEV === 'true') {
+      projectId = 'percy-dev';
+    }
     // Take screenshots via browserstack executor
     const response = await TimeIt.run('percyScreenshot:screenshot', async () => {
       return await this.browserstackExecutor('percyScreenshot', {
         state: 'screenshot',
         percyBuildId: utils.percy?.build?.id,
-        screenshotType: 'fullpage',
+        screenshotType,
+        projectId,
         scaleFactor: await this.metadata.scaleFactor(),
         options: {
           numOfTiles: screenLengths || 4,

--- a/test/percy/providers/appAutomateProvider.test.mjs
+++ b/test/percy/providers/appAutomateProvider.test.mjs
@@ -104,4 +104,40 @@ describe('AppAutomateProvider', () => {
       expect(appAutomate.debugUrl).toEqual(null);
     });
   });
+
+  describe('getTiles', () => {
+
+    it('when env isDisableRemoteUpload is true', async () => {
+      const appAutomate = new AppAutomateProvider(driver);
+      spyOn(AppAutomateProvider.prototype, 'isDisableRemoteUpload')
+                            .and.returnValue('true');
+      let superGetTilesSpy = spyOn(GenericProvider.prototype, 'getTiles');
+      superGetTilesSpy.and.resolveTo([])
+                            
+      await appAutomate.getTiles(true, false, null, null, null);
+      expect(superGetTilesSpy).toHaveBeenCalledWith(true, false, null);
+    });
+
+    it('when env isPercyDev is true', async () => {
+      const appAutomate = new AppAutomateProvider(driver);
+      spyOn(AppAutomateProvider.prototype, 'isPercyDev')
+                            .and.returnValue('true');
+      let superGetTilesSpy = spyOn(GenericProvider.prototype, 'getTiles');
+      let browserstack_executorSpy = spyOn(AppAutomateProvider.prototype, 'browserstackExecutor');
+      superGetTilesSpy.and.resolveTo([])
+      let response = {
+        success: true,
+        result: JSON.stringify([{header_height: 100, footer_height: 200, sha: "abc"}])
+      };
+      browserstack_executorSpy.and.resolveTo(response);
+      var screenSize = {
+        height: 2000,
+      }
+      appAutomate.metadata = { statusBarHeight: () => 100, navigationBarHeight: () => 200, scaleFactor: () => 1, screenSize: () => screenSize };
+                            
+      await appAutomate.getTiles(true, false, null, null, null);
+      expect(browserstack_executorSpy).toHaveBeenCalledWith('percyScreenshot', jasmine.any(Object));
+    });
+
+  });
 });

--- a/test/percy/providers/appAutomateProvider.test.mjs
+++ b/test/percy/providers/appAutomateProvider.test.mjs
@@ -106,38 +106,99 @@ describe('AppAutomateProvider', () => {
   });
 
   describe('getTiles', () => {
-
-    it('when env isDisableRemoteUpload is true', async () => {
-      const appAutomate = new AppAutomateProvider(driver);
-      spyOn(AppAutomateProvider.prototype, 'isDisableRemoteUpload')
-                            .and.returnValue('true');
-      let superGetTilesSpy = spyOn(GenericProvider.prototype, 'getTiles');
-      superGetTilesSpy.and.resolveTo([])
-                            
-      await appAutomate.getTiles(true, false, null, null, null);
-      expect(superGetTilesSpy).toHaveBeenCalledWith(true, false, null);
-    });
-
-    it('when env isPercyDev is true', async () => {
-      const appAutomate = new AppAutomateProvider(driver);
-      spyOn(AppAutomateProvider.prototype, 'isPercyDev')
-                            .and.returnValue('true');
-      let superGetTilesSpy = spyOn(GenericProvider.prototype, 'getTiles');
-      let browserstack_executorSpy = spyOn(AppAutomateProvider.prototype, 'browserstackExecutor');
-      superGetTilesSpy.and.resolveTo([])
-      let response = {
-        success: true,
-        result: JSON.stringify([{header_height: 100, footer_height: 200, sha: "abc"}])
-      };
-      browserstack_executorSpy.and.resolveTo(response);
-      var screenSize = {
-        height: 2000,
+    let args = {
+      state: 'screenshot',
+      percyBuildId: '123',
+      screenshotType: 'singlepage',
+      projectId: 'percy-prod',
+      scaleFactor: 1,
+      options: {
+        numOfTiles: 4,
+        deviceHeight: undefined,
+        scollableXpath: null,
+        scrollableId: null,
+        FORCE_FULL_PAGE: false
       }
-      appAutomate.metadata = { statusBarHeight: () => 100, navigationBarHeight: () => 200, scaleFactor: () => 1, screenSize: () => screenSize };
-                            
-      await appAutomate.getTiles(true, false, null, null, null);
-      expect(browserstack_executorSpy).toHaveBeenCalledWith('percyScreenshot', jasmine.any(Object));
+    }
+    describe ('when taking singlepage', () => {
+      describe ('when env isDisableRemoteUpload is true', () => {
+        it('takes a local appium screenshot', async () => {
+          const appAutomate = new AppAutomateProvider(driver);
+          spyOn(AppAutomateProvider.prototype, 'isDisableRemoteUpload')
+                                .and.returnValue('true');
+          let superGetTilesSpy = spyOn(GenericProvider.prototype, 'getTiles');
+          superGetTilesSpy.and.resolveTo([])
+                                
+          await appAutomate.getTiles(true, false, null, null, null);
+          expect(superGetTilesSpy).toHaveBeenCalledWith(true, false, null);
+        });
+      });
+
+      describe('when env isDisableRemoteUpload is false', () => {
+        it('takes screenshot with remote executor', async () => {
+          const appAutomate = new AppAutomateProvider(driver);
+          spyOn(AppAutomateProvider.prototype, 'isPercyDev')
+                                .and.returnValue('true');
+          let superGetTilesSpy = spyOn(GenericProvider.prototype, 'getTiles');
+          let browserstack_executorSpy = spyOn(AppAutomateProvider.prototype, 'browserstackExecutor');
+          superGetTilesSpy.and.resolveTo([])
+          let response = {
+            success: true,
+            result: JSON.stringify([{header_height: 100, footer_height: 200, sha: "abc"}])
+          };
+          browserstack_executorSpy.and.resolveTo(response);
+          var screenSize = {
+            height: 2000,
+          };
+          args['projectId'] = 'percy-dev';
+          args['options']['deviceHeight'] = screenSize['height'];
+          appAutomate.metadata = { statusBarHeight: () => 100, navigationBarHeight: () => 200, scaleFactor: () => 1, screenSize: () => screenSize };
+                                
+          await appAutomate.getTiles(true, false, null, null, null);
+          expect(browserstack_executorSpy).toHaveBeenCalledWith('percyScreenshot', args);
+        });
+      });
     });
 
+    describe ('when taking fullpage', () => {
+      describe ('when env isDisableRemoteUpload is true', () => {
+        it('takes a local appium screenshot', async () => {
+          const appAutomate = new AppAutomateProvider(driver);
+          spyOn(AppAutomateProvider.prototype, 'isDisableRemoteUpload')
+                                .and.returnValue('true');
+          let superGetTilesSpy = spyOn(GenericProvider.prototype, 'getTiles');
+          superGetTilesSpy.and.resolveTo([])
+                                
+          await appAutomate.getTiles(true, false, null, null, null);
+          expect(superGetTilesSpy).toHaveBeenCalledWith(true, false, null);
+        });
+      });
+
+      describe('when env isDisableRemoteUpload is false', () => {
+        it('takes screenshot with remote executor', async () => {
+          const appAutomate = new AppAutomateProvider(driver);
+          spyOn(AppAutomateProvider.prototype, 'isPercyDev')
+                                .and.returnValue('true');
+          let superGetTilesSpy = spyOn(GenericProvider.prototype, 'getTiles');
+          let browserstack_executorSpy = spyOn(AppAutomateProvider.prototype, 'browserstackExecutor');
+          superGetTilesSpy.and.resolveTo([])
+          let response = {
+            success: true,
+            result: JSON.stringify([{header_height: 100, footer_height: 200, sha: "abc"}])
+          };
+          browserstack_executorSpy.and.resolveTo(response);
+          var screenSize = {
+            height: 2000,
+          };
+          args['projectId'] = 'percy-dev';
+          args['options']['deviceHeight'] = screenSize['height'];
+          args['screenshotType'] = 'fullpage';
+          appAutomate.metadata = { statusBarHeight: () => 100, navigationBarHeight: () => 200, scaleFactor: () => 1, screenSize: () => screenSize };
+                                
+          await appAutomate.getTiles(true, true, null, null, null);
+          expect(browserstack_executorSpy).toHaveBeenCalledWith('percyScreenshot', args);
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
Taking singlepage ss for app automate from mobile.
Adding `PERCY_DISABLE_REMOTE_UPLOADS` env variable to override above.
Adding `PERCY_ENABLE_DEV` for dev. Added it so we can test better with sdk.