### PR TITLE
🐛  fix, additional full page options is not working

### DIFF
--- a/percy/providers/genericProvider.js
+++ b/percy/providers/genericProvider.js
@@ -51,10 +51,14 @@ class GenericProvider {
     considerRegionAppiumElements,
     customConsiderRegions,
     scrollableXpath,
+    topScrollviewOffset,
+    bottomScrollviewOffset,
     scrollableId,
     sync,
     testCase,
-    thTestCaseExecutionId
+    thTestCaseExecutionId,
+    androidScrollAreaPercentage,
+    scrollSpeed
   }) {
     fullscreen = fullscreen || false;
     sync = sync || null;
@@ -68,7 +72,17 @@ class GenericProvider {
     });
 
     const tag = await this.getTag();
-    const tiles = await this.getTiles(fullscreen, fullPage, screenLengths, scrollableXpath, scrollableId);
+    const tiles = await this.getTiles(
+      fullscreen,
+      fullPage,
+      screenLengths,
+      scrollableXpath,
+      topScrollviewOffset,
+      bottomScrollviewOffset,
+      scrollableId,
+      androidScrollAreaPercentage,
+      scrollSpeed
+    );
     const ignoreRegions = await this.findRegions(
       ignoreRegionXpaths, ignoreRegionAccessibilityIds, ignoreRegionAppiumElements, customIgnoreRegions
     );

--- a/test/index.test.mjs
+++ b/test/index.test.mjs
@@ -129,8 +129,15 @@ describe('percyScreenshot', () => {
                 it('posts full page screenshot to the local percy server', async () => {
                   driver = driverFunc({ platform, appAutomate });
 
-                  await percyScreenshot(driver, 'Screenshot 1', { fullPage: true });
-                  await percyScreenshot(driver, 'Screenshot 2', { fullPage: true });
+                  await percyScreenshot(driver, 'Screenshot 1', {
+                    fullPage: true,
+                    androidScrollAreaPercentage: 100
+                  });
+                  await percyScreenshot(driver, 'Screenshot 2', {
+                    fullPage: true,
+                    androidScrollAreaPercentage: 100,
+                    bottomScrollviewOffset: 100
+                  });
 
                   expect(await helpers.get('logs')).toEqual(jasmine.arrayContaining([
                     'Snapshot found: Screenshot 1',
@@ -242,7 +249,7 @@ describe('percyScreenshot', () => {
 
       it('should call POA percyScreenshot', async () => {
         const driver = driverFunc({ enabled: true });
-        spyOn(percyScreenshot, 'isPercyEnabled').and.returnValue(Promise.resolve(true))
+        spyOn(percyScreenshot, 'isPercyEnabled').and.returnValue(Promise.resolve(true));
         utils.percy.type = 'automate';
         const mockresponse = {};
         spyOn(percyOnAutomate, 'request').and.callFake(() => mockresponse);
@@ -259,7 +266,7 @@ describe('percyScreenshot', () => {
         const element = { value: '123', elementId: '123' };
         const element2 = { value: '456', elementId: '456' };
         const driver = driverFunc({ enabled: true });
-        spyOn(percyScreenshot, 'isPercyEnabled').and.returnValue(Promise.resolve(true))
+        spyOn(percyScreenshot, 'isPercyEnabled').and.returnValue(Promise.resolve(true));
         utils.percy.type = 'automate';
         spyOn(percyOnAutomate, 'request').and.callFake(() => {});
 
@@ -294,23 +301,23 @@ describe('percyScreenshot', () => {
         }));
       });
 
-      it('should return CLI response', async() => {
+      it('should return CLI response', async () => {
         const mockResponse = {
           success: true,
-          body: { data: { name: 'test_snapshot', some_data: 'some_data', some_obj: { some_obj: 'some_obj' }}}
-        }
+          body: { data: { name: 'test_snapshot', some_data: 'some_data', some_obj: { some_obj: 'some_obj' } } }
+        };
         const driver = driverFunc({ enabled: true });
-        spyOn(percyScreenshot, 'isPercyEnabled').and.returnValue(Promise.resolve(true))
+        spyOn(percyScreenshot, 'isPercyEnabled').and.returnValue(Promise.resolve(true));
         utils.percy.type = 'automate';
 
         spyOn(percyOnAutomate, 'request').and.callFake(() => mockResponse);
-        const response = await percyScreenshot(driver, 'Screenshot 1', { sync: true })
-        expect(response).toEqual(mockResponse.body.data)
-      })
+        const response = await percyScreenshot(driver, 'Screenshot 1', { sync: true });
+        expect(response).toEqual(mockResponse.body.data);
+      });
 
       it('should handle error POA', async () => {
         const driver = driverFunc({ enabled: true, ignoreErrors: false });
-        spyOn(percyScreenshot, 'isPercyEnabled').and.returnValue(Promise.resolve(true))
+        spyOn(percyScreenshot, 'isPercyEnabled').and.returnValue(Promise.resolve(true));
         utils.percy.type = 'automate';
         spyOn(percyOnAutomate, 'request').and.returnValue(Promise.reject(new Error('Not found 404')));
         let error = null;
@@ -324,7 +331,7 @@ describe('percyScreenshot', () => {
 
       it('should handle error POA ignoreError false', async () => {
         const driver = driverFunc({ enabled: true, ignoreErrors: true });
-        spyOn(percyScreenshot, 'isPercyEnabled').and.returnValue(Promise.resolve(true))
+        spyOn(percyScreenshot, 'isPercyEnabled').and.returnValue(Promise.resolve(true));
         utils.percy.type = 'automate';
         spyOn(percyOnAutomate, 'request').and.returnValue(Promise.reject(new Error('Not found 404')));
         let error = null;

--- a/test/percy/providers/appAutomateProvider.test.mjs
+++ b/test/percy/providers/appAutomateProvider.test.mjs
@@ -242,6 +242,35 @@ describe('AppAutomateProvider', () => {
           expect(browserstackExecutorSpy).toHaveBeenCalledWith('percyScreenshot', args);
         });
       });
+
+      describe('when other options are passed', () => {
+        it('takes screenshot with remote executor with "percy-dev" as projectId', async () => {
+          const appAutomate = new AppAutomateProvider(driver);
+          spyOn(AppAutomateProvider.prototype, 'isPercyDev')
+            .and.returnValue('true');
+          let superGetTilesSpy = spyOn(GenericProvider.prototype, 'getTiles');
+          let browserstackExecutorSpy = spyOn(AppAutomateProvider.prototype, 'browserstackExecutor');
+          superGetTilesSpy.and.resolveTo([]);
+          let response = {
+            success: true,
+            result: JSON.stringify([{ header_height: 100, footer_height: 200, sha: 'abc' }])
+          };
+          browserstackExecutorSpy.and.resolveTo(response);
+          var screenSize = {
+            height: 2000
+          };
+          args.projectId = 'percy-dev';
+          args.options.deviceHeight = screenSize.height;
+          args.options.topScrollviewOffset = 100;
+          args.options.bottomScrollviewOffset = 250;
+          args.options.androidScrollAreaPercentage = 50;
+          args.options.scrollSpeed = 500;
+          args.screenshotType = 'fullpage';
+          appAutomate.metadata = { statusBarHeight: () => 100, navigationBarHeight: () => 200, scaleFactor: () => 1, screenSize: () => screenSize };
+          await appAutomate.getTiles(true, true, null, null, 100, 250, null, 50, 500);
+          expect(browserstackExecutorSpy).toHaveBeenCalledWith('percyScreenshot', args);
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
We didn't update getTiles function in the generic provider class which was causing these optional parameter not working.
All args after scrollableId was not working.
Updated specs to catch this early.