### PR TITLE
[Per-4525] ignore region appium elements ios

### DIFF
--- a/percy/providers/genericProvider.js
+++ b/percy/providers/genericProvider.js
@@ -246,7 +246,7 @@ class GenericProvider {
     for (let index = 0; index < elements.length; index++) {
       try {
         const selector = `element: ${index}`;
-  
+
         const ignoredRegion = await this.getRegionObject(selector, elements[index]);
         elementsArray.push(ignoredRegion);
       } catch (e) {

--- a/percy/providers/genericProvider.js
+++ b/percy/providers/genericProvider.js
@@ -245,9 +245,8 @@ class GenericProvider {
   async getRegionsByElements(elementsArray, elements) {
     for (let index = 0; index < elements.length; index++) {
       try {
-        const type = await elements[index].getAttribute('class');
-        const selector = `element: ${index} ${type}`;
-
+        const selector = `element: ${index}`;
+  
         const ignoredRegion = await this.getRegionObject(selector, elements[index]);
         elementsArray.push(ignoredRegion);
       } catch (e) {

--- a/percy/providers/genericProvider.js
+++ b/percy/providers/genericProvider.js
@@ -249,13 +249,13 @@ class GenericProvider {
         const element = elements[index];
 
         const capabilities = await this.driver.getCapabilities();
-        const PLATFORM_NAME = capabilities.platformName.toLowerCase();
+        const platformName = capabilities.platformName.toLowerCase();
 
-        if (PLATFORM_NAME === 'android') {
+        if (platformName === 'android') {
           // Android identifiers
           identifier = await element.getAttribute('resource-id') ||
                     await element.getAttribute('class');
-        } else if (PLATFORM_NAME === 'ios') {
+        } else if (platformName === 'ios') {
           // iOS identifiers
           identifier = await element.getAttribute('name') ||
                     await element.getAttribute('type');

--- a/percy/providers/genericProvider.js
+++ b/percy/providers/genericProvider.js
@@ -249,7 +249,7 @@ class GenericProvider {
         const element = elements[index];
 
         const capabilities = await this.driver.getCapabilities();
-        const PLATFORM_NAME = (capabilities.platformName || '').toLowerCase();
+        const PLATFORM_NAME = capabilities.platformName.toLowerCase();
 
         if (PLATFORM_NAME === 'android') {
           // Android identifiers

--- a/percy/providers/genericProvider.js
+++ b/percy/providers/genericProvider.js
@@ -249,13 +249,13 @@ class GenericProvider {
         const element = elements[index];
 
         const capabilities = await this.driver.getCapabilities();
-        const platformName = (capabilities.platformName || '').toLowerCase();
+        const PLATFORM_NAME = (capabilities.platformName || '').toLowerCase();
 
-        if (platformName === 'android') {
+        if (PLATFORM_NAME === 'android') {
           // Android identifiers
           identifier = await element.getAttribute('resource-id') ||
                     await element.getAttribute('class');
-        } else if (platformName === 'ios') {
+        } else if (PLATFORM_NAME === 'ios') {
           // iOS identifiers
           identifier = await element.getAttribute('name') ||
                     await element.getAttribute('type');

--- a/percy/providers/genericProvider.js
+++ b/percy/providers/genericProvider.js
@@ -247,20 +247,20 @@ class GenericProvider {
       try {
         let identifier;
         const element = elements[index];
-        
+
         const capabilities = await this.driver.getCapabilities();
         const platformName = (capabilities.platformName || '').toLowerCase();
-        
+
         if (platformName === 'android') {
           // Android identifiers
-          identifier = await element.getAttribute('resource-id') || 
+          identifier = await element.getAttribute('resource-id') ||
                     await element.getAttribute('class');
-        } else if(platformName === 'ios') {
+        } else if (platformName === 'ios') {
           // iOS identifiers
-          identifier = await element.getAttribute('name') || 
+          identifier = await element.getAttribute('name') ||
                     await element.getAttribute('type');
         }
-  
+
         const selector = `element: ${index} ${identifier ? `${identifier}` : ''}`.trim();
         const ignoredRegion = await this.getRegionObject(selector, element);
         elementsArray.push(ignoredRegion);

--- a/percy/providers/genericProvider.js
+++ b/percy/providers/genericProvider.js
@@ -245,9 +245,24 @@ class GenericProvider {
   async getRegionsByElements(elementsArray, elements) {
     for (let index = 0; index < elements.length; index++) {
       try {
-        const selector = `element: ${index}`;
-
-        const ignoredRegion = await this.getRegionObject(selector, elements[index]);
+        let identifier;
+        const element = elements[index];
+        
+        const capabilities = await this.driver.getCapabilities();
+        const platformName = (capabilities.platformName || '').toLowerCase();
+        
+        if (platformName === 'android') {
+          // Android identifiers
+          identifier = await element.getAttribute('resource-id') || 
+                    await element.getAttribute('class');
+        } else if(platformName === 'ios') {
+          // iOS identifiers
+          identifier = await element.getAttribute('name') || 
+                    await element.getAttribute('type');
+        }
+  
+        const selector = `element: ${index} ${identifier ? `${identifier}` : ''}`.trim();
+        const ignoredRegion = await this.getRegionObject(selector, element);
         elementsArray.push(ignoredRegion);
       } catch (e) {
         log.info(`Correct Mobile Element not passed at index ${index}.`);

--- a/test/percy/providers/genericProvider.test.mjs
+++ b/test/percy/providers/genericProvider.test.mjs
@@ -222,24 +222,6 @@ describe('GenericProvider', () => {
         expect(elementsArray).toEqual([{}]);
       });
 
-      it('should handle missing platformName in capabilities', async () => {
-        mockDriver.getCapabilities.and.resolveTo({});
-        const elementsArray = [];
-        mockElement = {
-          getAttribute: jasmine.createSpy('getAttribute')
-            .and.returnValue('some-value')
-        };
-
-        await provider.getRegionsByElements.call(
-          { driver: mockDriver, getRegionObject: getRegionObjectSpy },
-          elementsArray,
-          [mockElement]
-        );
-
-        expect(getRegionObjectSpy).toHaveBeenCalledTimes(1);
-        expect(getRegionObjectSpy.calls.argsFor(0)[0]).toBe('element: 0');
-        expect(elementsArray).toEqual([{}]);
-      });
       describe('Android', () => {
         beforeEach(() => {
           mockDriver.getCapabilities.and.resolveTo({ platformName: 'android' });

--- a/test/percy/providers/genericProvider.test.mjs
+++ b/test/percy/providers/genericProvider.test.mjs
@@ -152,22 +152,43 @@ describe('GenericProvider', () => {
   describe('getRegionsByElements', () => {
     let getRegionObjectSpy;
     let mockElement;
+    let mockDriver;
 
     beforeEach(() => {
       getRegionObjectSpy = spyOn(provider, 'getRegionObject').and.resolveTo({});
-      mockElement = {
-        getAttribute: jasmine.createSpy().and.returnValue('some-class')
+      mockDriver = {
+        getCapabilities: jasmine.createSpy('getCapabilities')
       };
     });
 
     it('should get regions for each element', async () => {
+      // Set up mock driver with platform capability
+      mockDriver.getCapabilities.and.resolveTo({ platformName: 'android' });
+      
       const elementsArray = [];
+      mockElement = {
+        getAttribute: jasmine.createSpy('getAttribute')
+          .and.callFake(attr => {
+            if (attr === 'resource-id') return 'test_id';
+            if (attr === 'class') return 'android.widget.Button';
+            return null;
+          })
+      };
       const elements = [mockElement, mockElement, mockElement];
 
-      await provider.getRegionsByElements.call({ driver, getRegionObject: getRegionObjectSpy }, elementsArray, elements);
+      await provider.getRegionsByElements.call(
+        { driver: mockDriver, getRegionObject: getRegionObjectSpy },
+        elementsArray,
+        elements
+      );
 
       expect(getRegionObjectSpy).toHaveBeenCalledTimes(3);
       expect(elementsArray).toEqual([{}, {}, {}]);
+      
+      // Verify each call had correct selector
+      for (let i = 0; i < 3; i++) {
+        expect(getRegionObjectSpy.calls.argsFor(i)[0]).toBe(`element: ${i} test_id`);
+      }
     });
 
     it('should ignore when error', async () => {
@@ -181,33 +202,179 @@ describe('GenericProvider', () => {
       expect(elementsArray).toEqual([]);
     });
 
-    it('should add regions for valid elements', async () => {
-      const elementsArray = [];
-      const mockElements = [
-        {
-          getRect: jasmine.createSpy().and.resolveTo({ x: 10, y: 20, width: 100, height: 50 })
-        },
-        {
-          getRect: jasmine.createSpy().and.resolveTo({ x: 30, y: 40, width: 200, height: 60 })
-        }
-      ];
+    describe('Platform specific tests', () => {
+      it('should handle unknown platform', async () => {
+        mockDriver.getCapabilities.and.resolveTo({ platformName: 'unknown' });
+        const elementsArray = [];
+        mockElement = {
+          getAttribute: jasmine.createSpy('getAttribute')
+            .and.returnValue('some-value')
+        };
 
-      await provider.getRegionsByElements.call({ driver, getRegionObject: getRegionObjectSpy }, elementsArray, mockElements);
+        await provider.getRegionsByElements.call(
+          { driver: mockDriver, getRegionObject: getRegionObjectSpy },
+          elementsArray,
+          [mockElement]
+        );
 
-      expect(getRegionObjectSpy).toHaveBeenCalledTimes(2);
-      expect(getRegionObjectSpy.calls.argsFor(0)[0]).toBe('element: 0');
-      expect(getRegionObjectSpy.calls.argsFor(1)[0]).toBe('element: 1');
-      expect(elementsArray).toEqual([{}, {}]);
+        expect(getRegionObjectSpy).toHaveBeenCalledTimes(1);
+        expect(getRegionObjectSpy.calls.argsFor(0)[0]).toBe('element: 0');
+        expect(elementsArray).toEqual([{}]);
+      });
+
+      it('should handle missing platformName in capabilities', async () => {
+        mockDriver.getCapabilities.and.resolveTo({});
+        const elementsArray = [];
+        mockElement = {
+          getAttribute: jasmine.createSpy('getAttribute')
+            .and.returnValue('some-value')
+        };
+
+        await provider.getRegionsByElements.call(
+          { driver: mockDriver, getRegionObject: getRegionObjectSpy },
+          elementsArray,
+          [mockElement]
+        );
+
+        expect(getRegionObjectSpy).toHaveBeenCalledTimes(1);
+        expect(getRegionObjectSpy.calls.argsFor(0)[0]).toBe('element: 0');
+        expect(elementsArray).toEqual([{}]);
+      });
+      describe('Android', () => {
+        beforeEach(() => {
+          mockDriver.getCapabilities.and.resolveTo({ platformName: 'android' });
+        });
+  
+        it('should use resource-id as primary identifier', async () => {
+          const elementsArray = [];
+          mockElement = {
+            getAttribute: jasmine.createSpy('getAttribute')
+              .and.callFake(attr => {
+                if (attr === 'resource-id') return 'test_resource_id';
+                if (attr === 'class') return 'android.widget.Button';
+                return null;
+              })
+          };
+  
+          await provider.getRegionsByElements.call(
+            { driver: mockDriver, getRegionObject: getRegionObjectSpy },
+            elementsArray,
+            [mockElement]
+          );
+  
+          expect(getRegionObjectSpy).toHaveBeenCalledTimes(1);
+          expect(getRegionObjectSpy.calls.argsFor(0)[0]).toBe('element: 0 test_resource_id');
+          expect(elementsArray).toEqual([{}]);
+        });
+
+        it('should fallback to class when resource-id is not available', async () => {
+          const elementsArray = [];
+          mockElement = {
+            getAttribute: jasmine.createSpy('getAttribute')
+              .and.callFake(attr => {
+                if (attr === 'resource-id') return null;
+                if (attr === 'class') return 'android.widget.Button';
+                return null;
+              })
+          };
+  
+          await provider.getRegionsByElements.call(
+            { driver: mockDriver, getRegionObject: getRegionObjectSpy },
+            elementsArray,
+            [mockElement]
+          );
+  
+          expect(getRegionObjectSpy).toHaveBeenCalledTimes(1);
+          expect(getRegionObjectSpy.calls.argsFor(0)[0]).toBe('element: 0 android.widget.Button');
+          expect(elementsArray).toEqual([{}]);
+        });
+      });
+
+      describe('iOS', () => {
+        beforeEach(() => {
+          mockDriver.getCapabilities.and.resolveTo({ platformName: 'ios' });
+        });
+  
+        it('should use name as primary identifier', async () => {
+          const elementsArray = [];
+          mockElement = {
+            getAttribute: jasmine.createSpy('getAttribute')
+              .and.callFake(attr => {
+                if (attr === 'name') return 'TestButton';
+                if (attr === 'type') return 'XCUIElementTypeButton';
+                return null;
+              })
+          };
+  
+          await provider.getRegionsByElements.call(
+            { driver: mockDriver, getRegionObject: getRegionObjectSpy },
+            elementsArray,
+            [mockElement]
+          );
+  
+          expect(getRegionObjectSpy).toHaveBeenCalledTimes(1);
+          expect(getRegionObjectSpy.calls.argsFor(0)[0]).toBe('element: 0 TestButton');
+          expect(elementsArray).toEqual([{}]);
+        });
+
+        it('should fallback to type when name is not available', async () => {
+          const elementsArray = [];
+          mockElement = {
+            getAttribute: jasmine.createSpy('getAttribute')
+              .and.callFake(attr => {
+                if (attr === 'name') return null;
+                if (attr === 'type') return 'XCUIElementTypeButton';
+                return null;
+              })
+          };
+  
+          await provider.getRegionsByElements.call(
+            { driver: mockDriver, getRegionObject: getRegionObjectSpy },
+            elementsArray,
+            [mockElement]
+          );
+  
+          expect(getRegionObjectSpy).toHaveBeenCalledTimes(1);
+          expect(getRegionObjectSpy.calls.argsFor(0)[0]).toBe('element: 0 XCUIElementTypeButton');
+          expect(elementsArray).toEqual([{}]);
+        });
+      });
     });
 
-    it('should handle empty elements array', async () => {
-      const elementsArray = [];
-      const mockElements = [];
-
-      await provider.getRegionsByElements.call({ driver, getRegionObject: getRegionObjectSpy }, elementsArray, mockElements);
-
-      expect(getRegionObjectSpy).not.toHaveBeenCalled();
-      expect(elementsArray).toEqual([]);
+    describe('Error handling', () => {
+      it('should handle elements with no identifiers', async () => {
+        mockDriver.getCapabilities.and.resolveTo({ platformName: 'android' });
+        const elementsArray = [];
+        mockElement = {
+          getAttribute: jasmine.createSpy('getAttribute').and.returnValue(null)
+        };
+  
+        await provider.getRegionsByElements.call(
+          { driver: mockDriver, getRegionObject: getRegionObjectSpy },
+          elementsArray,
+          [mockElement]
+        );
+  
+        expect(getRegionObjectSpy).toHaveBeenCalledTimes(1);
+        expect(getRegionObjectSpy.calls.argsFor(0)[0]).toBe('element: 0');
+        expect(elementsArray).toEqual([{}]);
+      });
+  
+      it('should handle capability errors', async () => {
+        mockDriver.getCapabilities.and.rejectWith(new Error('Capabilities not found'));
+        const elementsArray = [];
+        mockElement = {
+          getAttribute: jasmine.createSpy('getAttribute')
+        };
+  
+        await provider.getRegionsByElements.call(
+          { driver: mockDriver, getRegionObject: getRegionObjectSpy },
+          elementsArray,
+          [mockElement]
+        );
+  
+        expect(elementsArray).toEqual([]);
+      });
     });
   });
 

--- a/test/percy/providers/genericProvider.test.mjs
+++ b/test/percy/providers/genericProvider.test.mjs
@@ -180,6 +180,35 @@ describe('GenericProvider', () => {
       // expect(getRegionObjectSpy).not.toHaveBeenCalled();
       expect(elementsArray).toEqual([]);
     });
+
+    it('should add regions for valid elements', async () => {
+      const elementsArray = [];
+      const mockElements = [
+        {
+          getRect: jasmine.createSpy().and.resolveTo({ x: 10, y: 20, width: 100, height: 50 })
+        },
+        {
+          getRect: jasmine.createSpy().and.resolveTo({ x: 30, y: 40, width: 200, height: 60 })
+        }
+      ];
+
+      await provider.getRegionsByElements.call({ driver, getRegionObject: getRegionObjectSpy }, elementsArray, mockElements);
+
+      expect(getRegionObjectSpy).toHaveBeenCalledTimes(2);
+      expect(getRegionObjectSpy.calls.argsFor(0)[0]).toBe('element: 0');
+      expect(getRegionObjectSpy.calls.argsFor(1)[0]).toBe('element: 1');
+      expect(elementsArray).toEqual([{}, {}]);
+    });
+
+    it('should handle empty elements array', async () => {
+      const elementsArray = [];
+      const mockElements = [];
+
+      await provider.getRegionsByElements.call({ driver, getRegionObject: getRegionObjectSpy }, elementsArray, mockElements);
+
+      expect(getRegionObjectSpy).not.toHaveBeenCalled();
+      expect(elementsArray).toEqual([]);
+    });
   });
 
   describe('getRegionsByLocation function', () => {


### PR DESCRIPTION
**The Problem:**

- The `getRegionsByElements` function needs to handle element identification differently for iOS and Android platforms. The key challenge is that different attributes are available and reliable on each platform. The existing implementation retrieves the `class` attribute, which isn't available on iOS XCUITest elements, leading to failures in element selection.
___
**Key changes made:**

Platform Detection

- Detect the platform using driver capabilities.
- Implement platform-specific logic separately
- Element Attributes Selection Strategy

Android:

- Primary Attribute: `resource-id`
- Fallback Attribute: `class`

iOS:

- Primary Attribute: `name`
- Fallback Attribute: `type`

Selector Generation

- Format: `element: {index} {identifier}`