### PR TITLE
Release v2.1.1-beta1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@percy/appium-app",
-  "version": "2.0.10",
+  "version": "2.1.1-beta1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@percy/appium-app",
-      "version": "2.0.10",
+      "version": "2.1.1-beta1",
       "license": "MIT",
       "dependencies": {
         "@percy/sdk-utils": "^1.30.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@percy/appium-app",
   "description": "Appium client library for visual testing with Percy",
-  "version": "2.1.0",
+  "version": "2.1.1-beta1",
   "license": "MIT",
   "author": "Perceptual Inc.",
   "repository": {
@@ -25,7 +25,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "scripts": {
     "lint": "eslint --ignore-path .gitignore .",


### PR DESCRIPTION
This PR prepares the release for version 2.1.1-beta1.

## Changes
- Bumped version from 2.1.0 to 2.1.1-beta1 in both `package.json` and `package-lock.json`
- Updated publish tag from "latest" to "beta" in `package.json`

This is a beta release that includes the iOS optimized fullpage attribute support from the previous feature branch.