### PR TITLE
Release v2.1.1-beta2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@percy/appium-app",
-  "version": "2.1.1-beta1",
+  "version": "2.1.1-beta2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@percy/appium-app",
-      "version": "2.1.1-beta1",
+      "version": "2.1.1-beta2",
       "license": "MIT",
       "dependencies": {
         "@percy/sdk-utils": "^1.30.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@percy/appium-app",
   "description": "Appium client library for visual testing with Percy",
-  "version": "2.1.1-beta1",
+  "version": "2.1.1-beta2",
   "license": "MIT",
   "author": "Perceptual Inc.",
   "repository": {


### PR DESCRIPTION
Version bump **`2.1.1-beta1` → `2.1.1-beta2`** to release the App Percy change merged in #574 (`projectId` on `percyScreenshot` begin/end, gated on opt-in; default behavior unchanged).

Touches `package.json` + `package-lock.json` only (version field; `publishConfig.tag` stays `beta`) — mirrors the previous beta release (#515).

**Next step:** review & merge, then publish a GitHub Release for `v2.1.1-beta2` — `release.yml` runs `npm publish` on release, shipping under the `beta` dist-tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)