### PR TITLE
Release v2.1.1-beta.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@percy/appium-app",
-  "version": "2.1.1-beta2",
+  "version": "2.1.1-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@percy/appium-app",
-      "version": "2.1.1-beta2",
+      "version": "2.1.1-beta.3",
       "license": "MIT",
       "dependencies": {
         "@percy/sdk-utils": "^1.30.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@percy/appium-app",
   "description": "Appium client library for visual testing with Percy",
-  "version": "2.1.1-beta2",
+  "version": "2.1.1-beta.3",
   "license": "MIT",
   "author": "Perceptual Inc.",
   "repository": {


### PR DESCRIPTION
Version bump to **2.1.1-beta.3** for the Appium version-compatibility work (PER-7786, #581).

- `package.json` / `package-lock.json`: 2.1.1-beta2 → 2.1.1-beta.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)