### PR TITLE
ci: fix CLI-branch injection env var typo (BRNACH → BRANCH)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up @percy/cli from git
         if: ${{ github.event_name == 'workflow_dispatch' }}
         env:
-          BRNACH: ${{ github.event.inputs.branch }}
+          BRANCH: ${{ github.event.inputs.branch }}
           WORKSPACE: ${{ github.workspace }} 
         run: |
           cd /tmp


### PR DESCRIPTION
## What

The `Set up @percy/cli from git` step in `test.yml` sets env var **`BRNACH`** (typo) but the clone reads **`$BRANCH`**:

```yaml
env:
  BRNACH: ${{ github.event.inputs.branch }}   # typo
run: |
  git clone --branch "$BRANCH" --depth 1 https://github.com/percy/cli   # $BRANCH is empty
```

So on a `workflow_dispatch` run, `$BRANCH` is empty and `git clone --branch ""` fails — **CLI-branch regression for this SDK never actually ran**. One-character fix: `BRNACH` → `BRANCH`.

## Why

Part of **PER-9772** (run SDK regression against an unpublished `@percy/cli` branch). This SDK looked injection-capable but was silently broken.

## Safety

No behavior change beyond fixing the var name. `branch` is still env-passed and validated by the existing regex-match step before this step runs.

## Test plan

- [ ] `workflow_dispatch` with a known `@percy/cli` branch → clone/build/link succeeds and `npx percy --version` reflects the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)