### PR TITLE
ci: fix CLI-from-git setup in test.yml (PER-9772)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,14 @@ jobs:
           yarn
           yarn build
           yarn global:link
+          # Expose the freshly built `percy` on PATH. yarn link symlinks the
+          # package but not its bin, so `npx percy` would miss it and download
+          # the unrelated public `percy`. Link is best-effort; PATH is what
+          # makes percy resolvable.
+          echo "$(yarn global bin)" >> "$GITHUB_PATH"
+          export PATH="$(yarn global bin):$PATH"
           cd "$WORKSPACE"
-          yarn remove @percy/cli && yarn link `echo $PERCY_PACKAGES`
-          npx percy --version
+          yarn remove @percy/cli >/dev/null 2>&1 || true
+          yarn link `echo $PERCY_PACKAGES` >/dev/null 2>&1 || true
+          percy --version
       - run: yarn test:coverage


### PR DESCRIPTION
Same bug as percy/percy-selenium-ruby#39, same fix.

## Problem
The `Set up @percy/cli from git` step (workflow_dispatch path, used by the [percy/cli SDK regression](https://github.com/percy/cli/pull/2322)) always fails: after `yarn remove @percy/cli` there is no local `percy` bin (`yarn link` symlinks packages, not bins), so `npx percy --version` falls back to downloading the **unrelated public `percy@5.0.0`** package, which prints "Heads up! It looks like @percy/cli is not installed!" and exits 1.

Failing job: https://github.com/percy/percy-appium-js/actions/runs/28640658402

## Fix
Mirror the working percy-capybara pattern: put `$(yarn global bin)` on `GITHUB_PATH` after `yarn global:link`, call `percy --version` directly, and make remove/link best-effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)